### PR TITLE
Toggle Physics Option

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -3645,7 +3645,7 @@ void Application::update(float deltaTime) {
 
     updateLOD();
 
-    if (!_physicsEnabled) {
+    if (!_physicsEnabled && !_physicsManuallyDisabled) {
         // we haven't yet enabled physics.  we wait until we think we have all the collision information
         // for nearby entities before starting bullet up.
         quint64 now = usecTimestampNow();
@@ -3986,6 +3986,18 @@ int Application::sendNackPackets() {
 
 
     return packetsSent;
+}
+
+void Application::togglePhysics() {
+	if(_physicsManuallyDisabled) {
+		_physicsManuallyDisabled = false;
+	}
+	else {
+		//set enable physics low if physics is disabled
+		_physicsEnabled = false;
+		_physicsManuallyDisabled = true;
+	}
+	return;
 }
 
 void Application::queryOctree(NodeType_t serverType, PacketType packetType, NodeToJurisdictionMap& jurisdictions, bool forceResend) {

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -335,6 +335,8 @@ public slots:
 
     void rotationModeChanged() const;
 
+	void togglePhysics();
+	
     static void runTests();
 
     QUuid getKeyboardFocusEntity() const;  // thread-safe
@@ -558,6 +560,8 @@ private:
     bool _isGLInitialized { false };
     bool _physicsEnabled { false };
 
+	bool _physicsManuallyDisabled = false;
+	
     bool _reticleClickPressed { false };
 
     int _avatarAttachmentRequest = 0;

--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -291,6 +291,10 @@ Menu::Menu() {
     // Settings > Developer Menus
     addCheckableActionToQMenuAndActionHash(settingsMenu, "Developer Menus", 0, false, this, SLOT(toggleDeveloperMenus()));
 
+	// Settings > Toggle Physics
+    addCheckableActionToQMenuAndActionHash(settingsMenu, MenuOption::TogglePhysics, 0, false, this, SLOT(togglePhysics()));
+
+
     // Settings > General...
     action = addActionToQMenuAndActionHash(settingsMenu, MenuOption::Preferences, Qt::CTRL | Qt::Key_Comma, nullptr, nullptr, QAction::PreferencesRole);
     connect(action, &QAction::triggered, [] {

--- a/interface/src/Menu.h
+++ b/interface/src/Menu.h
@@ -184,6 +184,7 @@ namespace MenuOption {
     const QString ThreePointCalibration = "3 Point Calibration";
     const QString ThrottleFPSIfNotFocus = "Throttle FPS If Not Focus"; // FIXME - this value duplicated in Basic2DWindowOpenGLDisplayPlugin.cpp
     const QString ToolWindow = "Tool Window";
+	const QString TogglePhysics = "Toggle Physics";
     const QString TransmitterDrive = "Transmitter Drive";
     const QString TurnWithHead = "Turn using Head";
     const QString UseAudioForMouth = "Use Audio for Mouth";


### PR DESCRIPTION
Added an option in the settings tab labeled "toggle physics" which will
disable and enable physics.

I wrote this code a week ago and was attempting to debug it but was
unable to pull up the dev-demo because my branch was too far out of sync
with the master branch.  When I attempted to sync up with the master
branch I was getting compiler errors (possibly caused by me having
Qt5.5). Tom has encouraged me to submit my code despite not being able
to compile or test it for review so please let me know if it has a bug
or if there is anything you would like me to add.

The problem that I chose to solve with this submission is the creation
of a drop down tab that would disable physics until the user reenabled
it again. I accomplished this by adding in a flag inside of Application
(interface\src\Application.h) called _physicsManuallyDisabled which
would store if the user disabled or enabled physics from the drop menu.
I added in the flag inside of the update() when the _physicsEnabled flag
is checked so that if physics is manually disabled then _physicsEnabled
will never be allowed to be set high until physics is enabled again.
Lastly, I control the value of _physicsManuallyDisabled through an
addition to the settings dropdown menu with I labeled "toggle physics".
When the user selects this option it calls the togglePhysics() function
which toggles the _physicsManuallyDisabled flag (as well as sets
_physicsEnabled low if physics is disabled).

Please feel free to contact me if you are having any issues with my code
or would like for me to provide any more clarity.

Ryan J
